### PR TITLE
[bug-fix] imageio showing infinity for video lenth

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -18,7 +18,7 @@ class Video:
     def __init__(self, path):
         self.path = path
         self.container = imageio.get_reader(path, 'ffmpeg')
-        self.length = self.container.get_length()
+        self.length = self.container.count_frames()
         self.fps = self.container.get_meta_data()['fps']
     
     def init_head(self):


### PR DESCRIPTION
Fixed the bug that leads to video length showing up as infinity as discussed in the issue https://github.com/DariusAf/MesoNet/issues/8#issuecomment-499616778

